### PR TITLE
Zap `openxlsx` and use `writexl` instead, fix #310

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rio
 Type: Package
 Title: A Swiss-Army Knife for Data I/O
-Version: 0.5.30
+Version: 0.5.31
 Authors@R: c(person("Jason", "Becker", role = "aut", email = "jason@jbecker.co"),
              person("Chung-hong", "Chan", role = c("aut", "cre"), email = "chainsawtiney@gmail.com",
 	     	     comment = c(ORCID = "0000-0002-6232-7530")),
@@ -49,9 +49,10 @@ Imports:
     curl (>= 0.6),
     data.table (>= 1.11.2),
     readxl (>= 0.1.1),
-    openxlsx,
     tibble,
-    stringi
+    stringi,
+    writexl,
+    lifecycle
 Suggests:
     datasets,
     bit64,

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 * `export_list` can write multiple data frames to a single archive file (e.g. zip, tar) or a directory #346 h/t David Schoch
 * `get_info` is added #350
 * POTENTIALLY BREAKING: `setclass` parameter is now authoritative. Therefore: `import("starwars.csv", data.table = TRUE, setclass = "tibble")` will return a tibble (unlike previous versions where a data.table is returned). The default class is data frame. You can either explicitly use the `setclass` parameter; or set the option: `options(rio.import.class = "data.table")`. h/t David Schoch #336
+* Use `writexl` instead of `openxlsx`. Option to read xlsx with `openxlsx` (i.e. `import("starwars.xlsx", readxl = FALSE)`) is always `TRUE`. The ability to overwrite an existing sheet in an existing xlsx file is also removed. It is against the design principle of `rio`.
 * Bug fixes
    - ... is correctly passed for exporting ODS and feather #318
    - POTENTIALLY BREAKING: JSON are exported in UTF-8 by default; solved encoding issues on

--- a/R/export.R
+++ b/R/export.R
@@ -21,7 +21,7 @@
 #'     \item SPSS (.sav), using [haven::write_sav()]
 #'     \item SPSS compressed (.zsav), using [haven::write_sav()]
 #'     \item Stata (.dta), using [haven::write_dta()]. Note that variable/column names containing dots (.) are not allowed and will produce an error.
-#'     \item Excel (.xlsx), using [openxlsx::write.xlsx()]. Existing workbooks are overwritten unless `which` is specified, in which case only the specified sheet (if it exists) is overwritten. If the file exists but the `which` sheet does not, data are added as a new sheet to the existing workbook. `x` can also be a list of data frames; the list entry names are used as sheet names.
+#'     \item Excel (.xlsx), using [writexl::write_xlsx()]. `x` can also be a list of data frames; the list entry names are used as sheet names.
 #'     \item R syntax object (.R), using [base::dput()] (by default) or [base::dump()] (if `format = 'dump'`)
 #'     \item Saved R objects (.RData,.rda), using [base::save()]. In this case, `x` can be a data frame, a named list of objects, an R environment, or a character vector containing the names of objects if a corresponding `envir` argument is specified.
 #'     \item Serialized R objects (.rds), using [base::saveRDS()]. In this case, `x` can be any serializable R object.

--- a/R/export_methods.R
+++ b/R/export_methods.R
@@ -219,34 +219,8 @@ export_delim <- function(file, x, fwrite = TRUE, sep = "\t", row.names = FALSE,
 }
 
 #' @export
-.export.rio_xlsx <- function(file, x, which, ...) {
-    dots <- list(...)
-    if (!missing(which)) {
-        if (file.exists(file)) {
-            wb <- openxlsx::loadWorkbook(file = file)
-            sheets <- openxlsx::getSheetNames(file = file)
-            if (is.numeric(which)) {
-                if (which <= length(sheets)) {
-                    which <- sheets[which]
-                } else {
-                    which <- paste("Sheet", length(sheets) + 1L)
-                }
-            }
-            if (!which %in% sheets) {
-                openxlsx::addWorksheet(wb, sheet = which)
-            } else {
-                openxlsx::removeWorksheet(wb, sheet = which)
-                openxlsx::addWorksheet(wb, sheet = which)
-                openxlsx::worksheetOrder(wb) <- sheets
-            }
-            openxlsx::writeData(wb, sheet = which, x = x)
-            openxlsx::saveWorkbook(wb, file = file, overwrite = TRUE)
-        } else {
-            openxlsx::write.xlsx(x = x, file = file, sheetName = which, ...)
-        }
-    } else {
-        openxlsx::write.xlsx(x = x, file = file, ...)
-    }
+.export.rio_xlsx <- function(file, x, ...) {
+    writexl::write_xlsx(x = x, path = file, ...)
 }
 
 #' @export

--- a/R/import.R
+++ b/R/import.R
@@ -26,7 +26,7 @@
 #'     \item SPSS compressed (.zsav), using [haven::read_sav()].
 #'     \item Stata (.dta), using [haven::read_dta()]. If `haven = FALSE`, [foreign::read.dta()] can be used.
 #'     \item SPSS Portable Files (.por), using [haven::read_por()].
-#'     \item Excel (.xls and .xlsx), using [readxl::read_excel()]. Use `which` to specify a sheet number. For .xlsx files, it is possible to set `readxl = FALSE`, so that [openxlsx::read.xlsx()] can be used instead of readxl (the default).
+#'     \item Excel (.xls and .xlsx), using [readxl::read_xlsx()] or [readxl::read_xls()]. Use `which` to specify a sheet number.
 #'     \item R syntax object (.R), using [base::dget()]
 #'     \item Saved R objects (.RData,.rda), using [base::load()] for single-object .Rdata files. Use `which` to specify an object name for multi-object .Rdata files. This can be any R object (not just a data frame).
 #'     \item Serialized R objects (.rds), using [base::readRDS()]. This can be any R object (not just a data frame).

--- a/R/import_methods.R
+++ b/R/import_methods.R
@@ -311,22 +311,16 @@ import_delim <-
 }
 
 #' @export
-.import.rio_xlsx <- function(file, which = 1, readxl = TRUE, ...) {
-    if (isTRUE(readxl)) {
-        .check_pkg_availability("readxl")
-        arg_reconcile(readxl::read_xlsx,
-            path = file, ..., sheet = which,
-            .docall = TRUE,
-            .remap = c(colNames = "col_names", na.strings = "na")
-        )
-    } else {
-        .check_pkg_availability("openxlsx")
-        arg_reconcile(openxlsx::read.xlsx,
-            xlsxFile = file, ..., sheet = which,
-            .docall = TRUE,
-            .remap = c(col_names = "colNames", na = "na.strings")
-        )
+.import.rio_xlsx <- function(file, which = 1, readxl = lifecycle::deprecated(), ...) {
+    if (lifecycle::is_present(readxl)) {
+        lifecycle::deprecate_warn(
+                       when = "0.5.31",
+                       what = "import(readxl)",
+                       details = "xlsx will always be read by `readxl`. The parameter `readxl` will be dropped in v2.0.0.")
     }
+    arg_reconcile(readxl::read_xlsx,
+            path = file, ..., sheet = which,
+            .docall = TRUE)
 }
 
 #' @export

--- a/man/export.Rd
+++ b/man/export.Rd
@@ -37,7 +37,7 @@ The output file can be to a compressed directory, simply by adding an appropriat
 \item SPSS (.sav), using \code{\link[haven:read_spss]{haven::write_sav()}}
 \item SPSS compressed (.zsav), using \code{\link[haven:read_spss]{haven::write_sav()}}
 \item Stata (.dta), using \code{\link[haven:read_dta]{haven::write_dta()}}. Note that variable/column names containing dots (.) are not allowed and will produce an error.
-\item Excel (.xlsx), using \code{\link[openxlsx:write.xlsx]{openxlsx::write.xlsx()}}. Existing workbooks are overwritten unless \code{which} is specified, in which case only the specified sheet (if it exists) is overwritten. If the file exists but the \code{which} sheet does not, data are added as a new sheet to the existing workbook. \code{x} can also be a list of data frames; the list entry names are used as sheet names.
+\item Excel (.xlsx), using \code{\link[writexl:write_xlsx]{writexl::write_xlsx()}}. \code{x} can also be a list of data frames; the list entry names are used as sheet names.
 \item R syntax object (.R), using \code{\link[base:dput]{base::dput()}} (by default) or \code{\link[base:dump]{base::dump()}} (if \code{format = 'dump'})
 \item Saved R objects (.RData,.rda), using \code{\link[base:save]{base::save()}}. In this case, \code{x} can be a data frame, a named list of objects, an R environment, or a character vector containing the names of objects if a corresponding \code{envir} argument is specified.
 \item Serialized R objects (.rds), using \code{\link[base:readRDS]{base::saveRDS()}}. In this case, \code{x} can be any serializable R object.

--- a/man/import.Rd
+++ b/man/import.Rd
@@ -49,7 +49,7 @@ This function imports a data frame or matrix from a data file with the file form
 \item SPSS compressed (.zsav), using \code{\link[haven:read_spss]{haven::read_sav()}}.
 \item Stata (.dta), using \code{\link[haven:read_dta]{haven::read_dta()}}. If \code{haven = FALSE}, \code{\link[foreign:read.dta]{foreign::read.dta()}} can be used.
 \item SPSS Portable Files (.por), using \code{\link[haven:read_spss]{haven::read_por()}}.
-\item Excel (.xls and .xlsx), using \code{\link[readxl:read_excel]{readxl::read_excel()}}. Use \code{which} to specify a sheet number. For .xlsx files, it is possible to set \code{readxl = FALSE}, so that \code{\link[openxlsx:read.xlsx]{openxlsx::read.xlsx()}} can be used instead of readxl (the default).
+\item Excel (.xls and .xlsx), using \code{\link[readxl:read_excel]{readxl::read_xlsx()}} or \code{\link[readxl:read_excel]{readxl::read_xls()}}. Use \code{which} to specify a sheet number.
 \item R syntax object (.R), using \code{\link[base:dput]{base::dget()}}
 \item Saved R objects (.RData,.rda), using \code{\link[base:load]{base::load()}} for single-object .Rdata files. Use \code{which} to specify an object name for multi-object .Rdata files. This can be any R object (not just a data frame).
 \item Serialized R objects (.rds), using \code{\link[base:readRDS]{base::readRDS()}}. This can be any R object (not just a data frame).

--- a/tests/testthat/test_format_xls.R
+++ b/tests/testthat/test_format_xls.R
@@ -15,6 +15,21 @@ test_that("Expert to Excel (.xlsx) a list", {
     expect_equal(readxl::excel_sheets(tempxlsx), c("mtcars3", "mtcars2", "mtcars1"))
 })
 
+test_that("Is `sheet` passed?", {
+    tempxlsx <- tempfile(fileext = ".xlsx")
+    export(list(
+    mtcars3 = mtcars[1:10, ],
+    mtcars2 = mtcars[11:20, ],
+    mtcars1 = mtcars[21:32, ]
+), tempxlsx)
+    expect_equal(readxl::excel_sheets(tempxlsx), c("mtcars3", "mtcars2", "mtcars1"))
+    content <- import(tempxlsx, sheet = "mtcars2")
+    expect_equal(content$mpg, mtcars[11:20, ]$mpg)
+    content <- import(tempxlsx, which = 2)
+    expect_equal(content$mpg, mtcars[11:20, ]$mpg)
+})
+
+
 test_that("readxl is deprecated", {
     lifecycle::expect_deprecated(import("iris.xlsx", readxl = TRUE))
     lifecycle::expect_deprecated(import("iris.xlsx", readxl = FALSE))

--- a/tests/testthat/test_format_xls.R
+++ b/tests/testthat/test_format_xls.R
@@ -5,6 +5,16 @@ test_that("Export to Excel (.xlsx)", {
     expect_true(export(iris, "iris.xlsx") %in% dir())
 })
 
+test_that("Expert to Excel (.xlsx) a list", {
+    tempxlsx <- tempfile(fileext = ".xlsx")
+    export(list(
+    mtcars3 = mtcars[1:10, ],
+    mtcars2 = mtcars[11:20, ],
+    mtcars1 = mtcars[21:32, ]
+), tempxlsx)
+    expect_equal(readxl::excel_sheets(tempxlsx), c("mtcars3", "mtcars2", "mtcars1"))
+})
+
 test_that("readxl is deprecated", {
     lifecycle::expect_deprecated(import("iris.xlsx", readxl = TRUE))
     lifecycle::expect_deprecated(import("iris.xlsx", readxl = FALSE))

--- a/tests/testthat/test_format_xls.R
+++ b/tests/testthat/test_format_xls.R
@@ -3,7 +3,11 @@ require("datasets")
 
 test_that("Export to Excel (.xlsx)", {
     expect_true(export(iris, "iris.xlsx") %in% dir())
-    expect_true(export(mtcars, "iris.xlsx", which = 2) %in% dir())
+})
+
+test_that("readxl is deprecated", {
+    lifecycle::expect_deprecated(import("iris.xlsx", readxl = TRUE))
+    lifecycle::expect_deprecated(import("iris.xlsx", readxl = FALSE))
 })
 
 test_that("Import from Excel (.xlsx)", {


### PR DESCRIPTION
* Introduce `lifecycle` (which is a dependency of `tibble` anyway) to implement the deprecation of `import(readxl)`.

* Remove the overwriting of existing sheets by using `which`.

Ref #343

But `which` is not yet mapped to `col_names` for export(). #326